### PR TITLE
Fix URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='rob@luminoso.com',
     license = "MIT-LICENSE",
-    url = 'http://github.com/LuminosoInsight/orderedset',
+    url = 'http://github.com/LuminosoInsight/ordered-set',
     platforms = ["any"],
     description = "A MutableSet that remembers its order, so that every entry has an index.",
     py_modules=['ordered_set'],


### PR DESCRIPTION
I couldn't find the source at first, thinking it had been removed.
