### PR TITLE
return False for __eq__ where other isn't iterable

### DIFF
--- a/ordered_set.py
+++ b/ordered_set.py
@@ -143,5 +143,11 @@ class OrderedSet(collections.MutableSet):
     def __eq__(self, other):
         if isinstance(other, OrderedSet):
             return len(self) == len(other) and self.items == other.items
-        return set(self) == set(other)
+        try:
+            other_as_set = set(other)
+        except TypeError:
+            # If `other` can't be converted into a set, it's not equal.
+            return False
+        else:
+            return set(self) == other_as_set
 


### PR DESCRIPTION
Currently it will throw an exception if you do something like

```
ordered_set([]) == x
```

Where `x` is any object that isn't iterable, eg. `None`. I made it return `False` instead as I think that's better behaviour.
