### PR TITLE
Use tox to run tests on multiple Python VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .*.swp
 *.egg-info
 dist/
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = pypy, py26, py27, py32, py33, py34
+
+[testenv]
+deps = nose
+commands = nosetests


### PR DESCRIPTION
You can run tests on all to-be-supported Python VMs using [tox][] or [detox][].

![screen shot 2014-11-05 at 2 39 58 pm](https://cloud.githubusercontent.com/assets/12431/4913279/33d18dba-64ae-11e4-8930-cf4387fe8ede.png)

[tox]: https://testrun.org/tox/
[detox]: https://pypi.python.org/pypi/detox