### PR TITLE
Add .travis.yml file for CI testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.egg-info
 dist/
 .tox/
+.coverage
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+  - "pypy3"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+
+install:
+  - python setup.py install 
+
+script:
+  - nosetests --with-coverage --cover-package=ordered_set
+
+after_success:
+  - pip install --quiet coveralls
+  - coveralls


### PR DESCRIPTION
See http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in.

Here's the [build](https://travis-ci.org/hayd/ordered-set/builds/59445553).

Note: This is an addition to tox, but if you turn it on, it runs the test suite on each commit and for each pull-request (as well as making the testing results public). If you add the repo to [coveralls](https://coveralls.io/), you can also see the coverage for each build.

~~Note2: Unfortunately travis is having an [outage](http://www.traviscistatus.com/incidents/crzxldg09nnr) at the moment (which is quite unusual), hopefully [this build](https://travis-ci.org/hayd/ordered-set/builds/59445553) will (eventually) pass...~~