### PR TITLE
Include license file in resulting tar.gz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ setup(
     platforms = ["any"],
     description = "A MutableSet that remembers its order, so that every entry has an index.",
     py_modules=['ordered_set'],
+    package_data={'': ['MIT-LICENSE']},
+    include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I am going to package this module for Fedora. And it is better for Fedora if tar.gz file contains the file with the license (it is better for auditing). Can you please include it with next version?