### PR TITLE
Conform to set API, update to pytest, add CI badges

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = ordered_set.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.egg-info
 dist/
 .tox/
+.coverage
+.pytest_cache
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+sudo: false
+
+cache:
+  apt: true
+  directories:
+  - $HOME/.cache/pip
+  - $HOME/download
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+before_install:
+  - pip install pip -U
+  - pip install pytest -U
+install:
+  - travis_retry pip install -e .
+script: 
+  - travis_wait pytest --cov-config .coveragerc --cov-report html --cov=ordered_set test.py
+    
+after_success: 
+  - codecov 
+cache: 
+    apt: true
+    directories:
+        - $HOME/.pip-cache
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - travis_retry pip install -e .
 script: 
-  - travis_wait pytest --cov-config .coveragerc --cov-report html --cov=ordered_set test.py
+  - travis_wait pytest --doctest-modules --cov-config .coveragerc --cov-report html --cov=ordered_set test.py
     
 after_success: 
   - codecov 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Travis](https://img.shields.io/travis/Erotemic/ordered-set/master.svg?label=Travis%20CI)](https://travis-ci.org/Erotemic/ordered-set)
+[![Codecov](https://codecov.io/github/Erotemic/ordered-set/badge.svg?branch=master&service=github)](https://codecov.io/github/Erotemic/ordered-set?branch=master)
+[![Appveyor](https://ci.appveyor.com/api/projects/status/github/Erotemic/ordered-set?svg=True)](https://ci.appveyor.com/project/Erotemic/ordered-set/branch/master)
+[![Pypi](https://img.shields.io/pypi/v/ordered-set.svg)](https://pypi.python.org/pypi/ordered-set)
+
+
 An OrderedSet is a custom MutableSet that remembers its order, so that every
 entry has an index that can be looked up.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Travis](https://img.shields.io/travis/Erotemic/ordered-set/master.svg?label=Travis%20CI)](https://travis-ci.org/Erotemic/ordered-set)
-[![Codecov](https://codecov.io/github/Erotemic/ordered-set/badge.svg?branch=master&service=github)](https://codecov.io/github/Erotemic/ordered-set?branch=master)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/github/Erotemic/ordered-set?svg=True)](https://ci.appveyor.com/project/Erotemic/ordered-set/branch/master)
+[![Travis](https://img.shields.io/travis/LuminosoInsight/ordered-set/master.svg?label=Travis%20CI)](https://travis-ci.org/LuminosoInsight/ordered-set)
+[![Codecov](https://codecov.io/github/LuminosoInsight/ordered-set/badge.svg?branch=master&service=github)](https://codecov.io/github/LuminosoInsight/ordered-set?branch=master)
 [![Pypi](https://img.shields.io/pypi/v/ordered-set.svg)](https://pypi.python.org/pypi/ordered-set)
 
 

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -57,8 +57,10 @@ class OrderedSet(collections.MutableSet):
         Returns the number of unique elements in the ordered set
 
         Example:
-            >>> assert len(OrderedSet([])) == 0
-            >>> assert len(OrderedSet([1, 2])) == 2
+            >>> len(OrderedSet([]))
+            0
+            >>> len(OrderedSet([1, 2]))
+            2
         """
         return len(self.items)
 
@@ -74,32 +76,20 @@ class OrderedSet(collections.MutableSet):
         "fancy indexing".
 
         Example:
-            >>> import pytest
             >>> self = OrderedSet([1, 2, 3])
-            >>> assert self[0] == 1
-            >>> assert self[1] == 2
-            >>> with pytest.raises(IndexError):
-            ...     self[3]
-            >>> assert self[-2] == 2
-            >>> assert self[-3] == 1
-            >>> with pytest.raises(IndexError):
-            ...     self[-4]
-            >>> assert self[::2] == [1, 3]
-            >>> assert self[0:2] == [1, 2]
-            >>> assert self[-1:] == [3]
-            >>> assert self[:] == self
-            >>> assert self[:] is not self
+            >>> self[1]
+            2
         """
         if index == SLICE_ALL:
             return self.copy()
         elif hasattr(index, '__index__') or isinstance(index, slice):
             result = self.items[index]
             if isinstance(result, list):
-                return OrderedSet(result)
+                return self.__class__(result)
             else:
                 return result
         elif is_iterable(index):
-            return OrderedSet([self.items[i] for i in index])
+            return self.__class__([self.items[i] for i in index])
         else:
             raise TypeError(
                 "Don't know how to index an OrderedSet by %r" % index)
@@ -111,9 +101,12 @@ class OrderedSet(collections.MutableSet):
         Example:
             >>> self = OrderedSet([1, 2, 3])
             >>> other = self.copy()
-            >>> assert self == other and self is not other
+            >>> self == other
+            True
+            >>> self is other
+            False
         """
-        return OrderedSet(self)
+        return self.__class__(self)
 
     def __getstate__(self):
         if len(self) == 0:
@@ -138,8 +131,10 @@ class OrderedSet(collections.MutableSet):
         Test if the item is in this ordered set
 
         Example:
-            >>> assert 1 in OrderedSet([1, 3, 2])
-            >>> assert 5 not in OrderedSet([1, 3, 2])
+            >>> 1 in OrderedSet([1, 3, 2])
+            True
+            >>> 5 in OrderedSet([1, 3, 2])
+            False
         """
         return key in self.map
 
@@ -192,13 +187,9 @@ class OrderedSet(collections.MutableSet):
         this returns a list of indices.
 
         Example:
-            >>> import pytest
             >>> self = OrderedSet([1, 2, 3])
-            >>> assert self.index(1) == 0
-            >>> assert self.index(2) == 1
-            >>> assert self.index(3) == 2
-            >>> with pytest.raises(IndexError):
-            ...     self[4]
+            >>> self.index(2)
+            1
         """
         if is_iterable(key):
             return [self.index(subkey) for subkey in key]
@@ -211,13 +202,9 @@ class OrderedSet(collections.MutableSet):
         Raises KeyError if the set is empty.
 
         Example:
-            >>> import pytest
             >>> self = OrderedSet([1, 2, 3])
-            >>> assert self.pop() == 3
-            >>> assert self.pop() == 2
-            >>> assert self.pop() == 1
-            >>> with pytest.raises(KeyError):
-            ...     self.pop()
+            >>> self.pop()
+            3
         """
         if not self.items:
             raise KeyError('Set is empty')
@@ -286,11 +273,14 @@ class OrderedSet(collections.MutableSet):
 
         Example:
             >>> self = OrderedSet([1, 3, 2])
-            >>> assert self == [1, 3, 2]
-            >>> assert self == [1, 2, 3]
-            >>> assert self != [2, 3]
-            >>> # assert self == OrderedSet([3, 2, 1])
-            >>> assert self != OrderedSet([3, 2, 1])
+            >>> self == [1, 3, 2]
+            True
+            >>> self == [1, 2, 3]
+            True
+            >>> self == [2, 3]
+            False
+            >>> self == OrderedSet([3, 2, 1])
+            False
         """
         if isinstance(other, OrderedSet):
             return len(self) == len(other) and self.items == other.items

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -37,7 +37,7 @@ def is_iterable(obj):
     return hasattr(obj, '__iter__') and not isinstance(obj, str) and not isinstance(obj, tuple)
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.MutableSet, collections.Sequence):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.
@@ -268,22 +268,25 @@ class OrderedSet(collections.MutableSet):
 
     def __eq__(self, other):
         """
-        Returns true if the containers have the same items. If `other` is an
-        OrderedSet, then order is checked, otherwise it is ignored.
+        Returns true if the containers have the same items. If `other` is a
+        Sequence, then order is checked, otherwise it is ignored.
 
         Example:
             >>> self = OrderedSet([1, 3, 2])
             >>> self == [1, 3, 2]
             True
             >>> self == [1, 2, 3]
-            True
+            False
             >>> self == [2, 3]
             False
             >>> self == OrderedSet([3, 2, 1])
             False
         """
-        if isinstance(other, OrderedSet):
-            return len(self) == len(other) and self.items == other.items
+        # In python 2 deque is not a Sequence,
+        # always treat deque it as one for compatibility
+        if isinstance(other, (collections.Sequence, collections.deque)):
+            # Ordered Check
+            return len(self) == len(other) and self.items == list(other)
         try:
             other_as_set = set(other)
         except TypeError:

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -18,7 +18,7 @@ import collections
 import itertools as it
 
 SLICE_ALL = slice(None)
-__version__ = '2.0.1'
+__version__ = '3.0.0'
 
 
 def is_iterable(obj):

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -41,6 +41,10 @@ class OrderedSet(collections.MutableSet):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.
+
+    Example:
+        >>> OrderedSet([1, 1, 2, 3, 2])
+        OrderedSet([1, 2, 3])
     """
     def __init__(self, iterable=None):
         self.items = []
@@ -49,6 +53,13 @@ class OrderedSet(collections.MutableSet):
             self |= iterable
 
     def __len__(self):
+        """
+        Returns the number of unique elements in the ordered set
+
+        Example:
+            >>> assert len(OrderedSet([])) == 0
+            >>> assert len(OrderedSet([1, 2])) == 2
+        """
         return len(self.items)
 
     def __getitem__(self, index):
@@ -61,6 +72,23 @@ class OrderedSet(collections.MutableSet):
         If `index` is an iterable, you'll get the OrderedSet of items
         corresponding to those indices. This is similar to NumPy's
         "fancy indexing".
+
+        Example:
+            >>> import pytest
+            >>> self = OrderedSet([1, 2, 3])
+            >>> assert self[0] == 1
+            >>> assert self[1] == 2
+            >>> with pytest.raises(IndexError):
+            ...     self[3]
+            >>> assert self[-2] == 2
+            >>> assert self[-3] == 1
+            >>> with pytest.raises(IndexError):
+            ...     self[-4]
+            >>> assert self[::2] == [1, 3]
+            >>> assert self[0:2] == [1, 2]
+            >>> assert self[-1:] == [3]
+            >>> assert self[:] == self
+            >>> assert self[:] is not self
         """
         if index == SLICE_ALL:
             return self.copy()
@@ -77,6 +105,14 @@ class OrderedSet(collections.MutableSet):
                 "Don't know how to index an OrderedSet by %r" % index)
 
     def copy(self):
+        """
+        Return a shallow copy of this object.
+
+        Example:
+            >>> self = OrderedSet([1, 2, 3])
+            >>> other = self.copy()
+            >>> assert self == other and self is not other
+        """
         return OrderedSet(self)
 
     def __getstate__(self):
@@ -98,6 +134,13 @@ class OrderedSet(collections.MutableSet):
             self.__init__(state)
 
     def __contains__(self, key):
+        """
+        Test if the item is in this ordered set
+
+        Example:
+            >>> assert 1 in OrderedSet([1, 3, 2])
+            >>> assert 5 not in OrderedSet([1, 3, 2])
+        """
         return key in self.map
 
     def add(self, key):
@@ -106,6 +149,13 @@ class OrderedSet(collections.MutableSet):
 
         If `key` is already in the OrderedSet, return the index it already
         had.
+
+        Example:
+            >>> self = OrderedSet()
+            >>> self.append(3)
+            0
+            >>> print(self)
+            OrderedSet([3])
         """
         if key not in self.map:
             self.map[key] = len(self.items)
@@ -117,6 +167,13 @@ class OrderedSet(collections.MutableSet):
         """
         Update the set with the given iterable sequence, then return the index
         of the last element inserted.
+
+        Example:
+            >>> self = OrderedSet([1, 2, 3])
+            >>> self.update([3, 1, 5, 1, 4])
+            4
+            >>> print(self)
+            OrderedSet([1, 2, 3, 5, 4])
         """
         item_index = None
         try:
@@ -133,6 +190,15 @@ class OrderedSet(collections.MutableSet):
 
         `key` can be an iterable of entries that is not a string, in which case
         this returns a list of indices.
+
+        Example:
+            >>> import pytest
+            >>> self = OrderedSet([1, 2, 3])
+            >>> assert self.index(1) == 0
+            >>> assert self.index(2) == 1
+            >>> assert self.index(3) == 2
+            >>> with pytest.raises(IndexError):
+            ...     self[4]
         """
         if is_iterable(key):
             return [self.index(subkey) for subkey in key]
@@ -143,6 +209,15 @@ class OrderedSet(collections.MutableSet):
         Remove and return the last element from the set.
 
         Raises KeyError if the set is empty.
+
+        Example:
+            >>> import pytest
+            >>> self = OrderedSet([1, 2, 3])
+            >>> assert self.pop() == 3
+            >>> assert self.pop() == 2
+            >>> assert self.pop() == 1
+            >>> with pytest.raises(KeyError):
+            ...     self.pop()
         """
         if not self.items:
             raise KeyError('Set is empty')
@@ -158,6 +233,15 @@ class OrderedSet(collections.MutableSet):
 
         The MutableSet mixin uses this to implement the .remove() method, which
         *does* raise an error when asked to remove a non-existent item.
+
+        Example:
+            >>> self = OrderedSet([1, 2, 3])
+            >>> self.discard(2)
+            >>> print(self)
+            OrderedSet([1, 3])
+            >>> self.discard(2)
+            >>> print(self)
+            OrderedSet([1, 3])
         """
         if key in self:
             i = self.map[key]
@@ -175,9 +259,19 @@ class OrderedSet(collections.MutableSet):
         self.map.clear()
 
     def __iter__(self):
+        """
+        Example:
+            >>> list(iter(OrderedSet([1, 2, 3])))
+            [1, 2, 3]
+        """
         return iter(self.items)
 
     def __reversed__(self):
+        """
+        Example:
+            >>> list(reversed(OrderedSet([1, 2, 3])))
+            [3, 2, 1]
+        """
         return reversed(self.items)
 
     def __repr__(self):
@@ -186,6 +280,18 @@ class OrderedSet(collections.MutableSet):
         return '%s(%r)' % (self.__class__.__name__, list(self))
 
     def __eq__(self, other):
+        """
+        Returns true if the containers have the same items. If `other` is an
+        OrderedSet, then order is checked, otherwise it is ignored.
+
+        Example:
+            >>> self = OrderedSet([1, 3, 2])
+            >>> assert self == [1, 3, 2]
+            >>> assert self == [1, 2, 3]
+            >>> assert self != [2, 3]
+            >>> # assert self == OrderedSet([3, 2, 1])
+            >>> assert self != OrderedSet([3, 2, 1])
+        """
         if isinstance(other, OrderedSet):
             return len(self) == len(other) and self.items == other.items
         try:
@@ -202,14 +308,14 @@ class OrderedSet(collections.MutableSet):
         Each items order is defined by its first appearance.
 
         Example:
-            >>> self = OrderedSet.union(oset([3, 1, 4, 1, 5]), [1, 3], [2, 0])
+            >>> self = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
             >>> print(self)
             OrderedSet([3, 1, 4, 5, 2, 0])
             >>> self.union([8, 9])
             OrderedSet([3, 1, 4, 5, 2, 0, 8, 9])
             >>> self | {10}
             OrderedSet([3, 1, 4, 5, 2, 0, 10])
-            >>> OrderedSet.union(oset([1, 2, 3]))
+            >>> OrderedSet.union(OrderedSet([1, 2, 3]))
             OrderedSet([1, 2, 3])
         """
         cls = self.__class__ if isinstance(self, OrderedSet) else OrderedSet
@@ -223,12 +329,12 @@ class OrderedSet(collections.MutableSet):
         by the first set.
 
         Example:
-            >>> self = OrderedSet.intersection(oset([0, 1, 2, 3]), [1, 2, 3])
+            >>> self = OrderedSet.intersection(OrderedSet([0, 1, 2, 3]), [1, 2, 3])
             >>> print(self)
             OrderedSet([1, 2, 3])
             >>> self.intersection([2, 4, 5], [1, 2, 3, 4])
             OrderedSet([2])
-            >>> OrderedSet.intersection(oset([1, 2, 3]))
+            >>> OrderedSet.intersection(OrderedSet([1, 2, 3]))
             OrderedSet([1, 2, 3])
         """
         cls = self.__class__ if isinstance(self, OrderedSet) else OrderedSet

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --doctest-modules test.py ordered_set.py
+
+norecursedirs = .git ignore build __pycache__

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['MIT-LICENSE']},
     include_package_data=True,
     test_suite='nose.collector',
-    tests_require=['nose'],
+    tests_require=['pytest'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/test.py
+++ b/test.py
@@ -131,218 +131,23 @@ def test_pop():
     pytest.raises(KeyError, set1.pop)
 
 
-def test_OrderedSet():
-    OrderedSet([1, 2, 3])
-    # doctest want:
-    # OrderedSet([1, 2, 3])
+def test_getitem_type_error():
+    set1 = OrderedSet('ab')
+    with pytest.raises(TypeError):
+        set1['a']
 
 
-def test_OrderedSet___len__():
-    assert len(OrderedSet([])) == 0
-    assert len(OrderedSet([1, 2])) == 2
+def test_update_value_error():
+    set1 = OrderedSet('ab')
+    with pytest.raises(ValueError):
+        set1.update(3)
 
 
-def test_OrderedSet___contains__():
-    assert 1 in OrderedSet([1, 3, 2])
-    assert 5 not in OrderedSet([1, 3, 2])
+def test_empty_repr():
+    set1 = OrderedSet()
+    assert repr(set1) == 'OrderedSet()'
 
 
-def test_OrderedSet___eq__():
-    self = OrderedSet([1, 3, 2])
-    assert self == [1, 3, 2]
-    assert self == [1, 2, 3]
-    assert self != [2, 3]
-    # assert self == OrderedSet([3, 2, 1])
-    assert self != OrderedSet([3, 2, 1])
-
-
-def test_OrderedSet___iter__():
-    list(iter(OrderedSet([1, 2, 3])))
-    # doctest want:
-    # [1, 2, 3]
-
-
-def test_OrderedSet___reversed__():
-    list(reversed(OrderedSet([1, 2, 3])))
-    # doctest want:
-    # [3, 2, 1]
-
-
-def test_OrderedSet___getitem__():
-    import pytest
-    self = OrderedSet([1, 2, 3])
-    assert self[0] == 1
-    assert self[1] == 2
-    assert self[2] == 3
-    with pytest.raises(IndexError):
-        self[3]
-    assert self[-1] == 3
-    assert self[-2] == 2
-    assert self[-3] == 1
-    with pytest.raises(IndexError):
-        self[-4]
-    assert self[::2] == [1, 3]
-    assert self[0:2] == [1, 2]
-    assert self[-1:] == [3]
-    assert self[:] == self
-    assert self[:] is not self
-
-
-def test_OrderedSet_add():
-    self = OrderedSet()
-    self.append(3)
-    print(self)
-    # doctest want:
-    # OrderedSet([3])
-
-
-def test_OrderedSet_append():
-    self = OrderedSet()
-    self.append(3)
-    self.append(2)
-    self.append(5)
-    print(self)
-    # doctest want:
-    # OrderedSet([3, 2, 5])
-
-
-def test_OrderedSet_discard():
-    self = OrderedSet([1, 2, 3])
-    self.discard(2)
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 3])
-    self.discard(2)
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 3])
-
-
-def test_OrderedSet_pop():
-    import pytest
-    self = OrderedSet([2, 3, 1])
-    assert self.pop() == 1
-    assert self.pop() == 3
-    assert self.pop() == 2
-    with pytest.raises(KeyError):
-        self.pop()
-
-
-def test_OrderedSet_union():
-    self = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
-    print(self)
-    # doctest want:
-    # OrderedSet([3, 1, 4, 5, 2, 0])
-    self.union([8, 9])
-    # doctest want:
-    # OrderedSet([3, 1, 4, 5, 2, 0, 8, 9])
-    self | {10}
-    # doctest want:
-    # OrderedSet([3, 1, 4, 5, 2, 0, 10])
-    OrderedSet.union(OrderedSet([1, 2, 3]))
-    # doctest want:
-    # OrderedSet([1, 2, 3])
-
-
-def test_OrderedSet_intersection():
-    self = OrderedSet.intersection(OrderedSet([0, 1, 2, 3]), [1, 2, 3])
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 2, 3])
-    self.intersection([2, 4, 5], [1, 2, 3, 4])
-    # doctest want:
-    # OrderedSet([2])
-    OrderedSet.intersection(OrderedSet([1, 2, 3]))
-    # doctest want:
-    # OrderedSet([1, 2, 3])
-
-
-def test_OrderedSet_update():
-    self = OrderedSet([1, 2, 3])
-    self.update([3, 1, 5, 1, 4])
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 2, 3, 5, 4])
-
-
-def test_OrderedSet_index():
-    import pytest
-    self = OrderedSet([1, 2, 3])
-    assert self.index(1) == 0
-    assert self.index(2) == 1
-    assert self.index(3) == 2
-    with pytest.raises(IndexError):
-        self[4]
-
-
-def test_OrderedSet_copy():
-    self = OrderedSet([1, 2, 3])
-    other = self.copy()
-    assert self == other and self is not other
-
-
-def test_OrderedSet_difference():
-    OrderedSet([1, 2, 3]).difference(OrderedSet([2]))
-    # doctest want:
-    # OrderedSet([1, 3])
-    OrderedSet([1, 2, 3]) - OrderedSet([2])
-    # doctest want:
-    # OrderedSet([1, 3])
-
-
-def test_OrderedSet_issubset():
-    OrderedSet([1, 2, 3]).issubset({1, 2})
-    # doctest want:
-    # False
-    OrderedSet([1, 2, 3]).issubset({1, 2, 3, 4})
-    # doctest want:
-    # True
-    OrderedSet([1, 2, 3]).issubset({1, 4, 3, 5})
-    # doctest want:
-    # False
-
-
-def test_OrderedSet_issuperset():
-    OrderedSet([1, 2]).issuperset([1, 2, 3])
-    # doctest want:
-    # False
-    OrderedSet([1, 2, 3, 4]).issuperset({1, 2, 3})
-    # doctest want:
-    # True
-    OrderedSet([1, 4, 3, 5]).issuperset({1, 2, 3})
-    # doctest want:
-    # False
-
-
-def test_OrderedSet_symmetric_difference():
-    self = OrderedSet([1, 4, 3, 5, 7])
-    other = OrderedSet([9, 7, 1, 3, 2])
-    self.symmetric_difference(other)
-    # doctest want:
-    # OrderedSet([4, 5, 9, 2])
-
-
-def test_OrderedSet_difference_update():
-    self = OrderedSet([1, 2, 3])
-    self.difference_update(OrderedSet([2]))
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 3])
-
-
-def test_OrderedSet_intersection_update():
-    self = OrderedSet([1, 4, 3, 5, 7])
-    other = OrderedSet([9, 7, 1, 3, 2])
-    self.intersection_update(other)
-    print(self)
-    # doctest want:
-    # OrderedSet([1, 3, 7])
-
-
-def test_OrderedSet_symmetric_difference_update():
-    self = OrderedSet([1, 4, 3, 5, 7])
-    other = OrderedSet([9, 7, 1, 3, 2])
-    self.symmetric_difference_update(other)
-    print(self)
-    # doctest want:
-    # OrderedSet([4, 5, 9, 2])
+def test_eq_wrong_type():
+    set1 = OrderedSet()
+    assert set1 != 2

--- a/test.py
+++ b/test.py
@@ -1,6 +1,11 @@
-from nose.tools import eq_, raises, assert_raises
-from ordered_set import OrderedSet
 import pickle
+import pytest
+from ordered_set import OrderedSet
+
+
+def eq_(item1, item2):
+    # replacement for a nosetest util
+    assert item1 == item2
 
 
 def test_pickle():
@@ -36,7 +41,8 @@ def test_indexing():
     set1 = OrderedSet('abracadabra')
     eq_(set1[:], set1)
     eq_(set1.copy(), set1)
-    assert set1[:] is set1
+    assert set1 is set1
+    assert set1[:] is not set1
     assert set1.copy() is not set1
 
     eq_(set1[[1, 2]], OrderedSet(['b', 'r']))
@@ -83,11 +89,11 @@ def test_remove():
     set1.discard('a')
 
 
-@raises(KeyError)
 def test_remove_error():
     # If we .remove() an element that's not there, we get a KeyError
     set1 = OrderedSet('abracadabra')
-    set1.remove('z')
+    with pytest.raises(KeyError):
+        set1.remove('z')
 
 
 def test_clear():
@@ -122,5 +128,221 @@ def test_pop():
 
     assert elem == 'a'
 
-    assert_raises(KeyError, set1.pop)
+    pytest.raises(KeyError, set1.pop)
 
+
+def test_OrderedSet():
+    OrderedSet([1, 2, 3])
+    # doctest want:
+    # OrderedSet([1, 2, 3])
+
+
+def test_OrderedSet___len__():
+    assert len(OrderedSet([])) == 0
+    assert len(OrderedSet([1, 2])) == 2
+
+
+def test_OrderedSet___contains__():
+    assert 1 in OrderedSet([1, 3, 2])
+    assert 5 not in OrderedSet([1, 3, 2])
+
+
+def test_OrderedSet___eq__():
+    self = OrderedSet([1, 3, 2])
+    assert self == [1, 3, 2]
+    assert self == [1, 2, 3]
+    assert self != [2, 3]
+    # assert self == OrderedSet([3, 2, 1])
+    assert self != OrderedSet([3, 2, 1])
+
+
+def test_OrderedSet___iter__():
+    list(iter(OrderedSet([1, 2, 3])))
+    # doctest want:
+    # [1, 2, 3]
+
+
+def test_OrderedSet___reversed__():
+    list(reversed(OrderedSet([1, 2, 3])))
+    # doctest want:
+    # [3, 2, 1]
+
+
+def test_OrderedSet___getitem__():
+    import pytest
+    self = OrderedSet([1, 2, 3])
+    assert self[0] == 1
+    assert self[1] == 2
+    assert self[2] == 3
+    with pytest.raises(IndexError):
+        self[3]
+    assert self[-1] == 3
+    assert self[-2] == 2
+    assert self[-3] == 1
+    with pytest.raises(IndexError):
+        self[-4]
+    assert self[::2] == [1, 3]
+    assert self[0:2] == [1, 2]
+    assert self[-1:] == [3]
+    assert self[:] == self
+    assert self[:] is not self
+
+
+def test_OrderedSet_add():
+    self = OrderedSet()
+    self.append(3)
+    print(self)
+    # doctest want:
+    # OrderedSet([3])
+
+
+def test_OrderedSet_append():
+    self = OrderedSet()
+    self.append(3)
+    self.append(2)
+    self.append(5)
+    print(self)
+    # doctest want:
+    # OrderedSet([3, 2, 5])
+
+
+def test_OrderedSet_discard():
+    self = OrderedSet([1, 2, 3])
+    self.discard(2)
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 3])
+    self.discard(2)
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 3])
+
+
+def test_OrderedSet_pop():
+    import pytest
+    self = OrderedSet([2, 3, 1])
+    assert self.pop() == 1
+    assert self.pop() == 3
+    assert self.pop() == 2
+    with pytest.raises(KeyError):
+        self.pop()
+
+
+def test_OrderedSet_union():
+    self = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
+    print(self)
+    # doctest want:
+    # OrderedSet([3, 1, 4, 5, 2, 0])
+    self.union([8, 9])
+    # doctest want:
+    # OrderedSet([3, 1, 4, 5, 2, 0, 8, 9])
+    self | {10}
+    # doctest want:
+    # OrderedSet([3, 1, 4, 5, 2, 0, 10])
+    OrderedSet.union(OrderedSet([1, 2, 3]))
+    # doctest want:
+    # OrderedSet([1, 2, 3])
+
+
+def test_OrderedSet_intersection():
+    self = OrderedSet.intersection(OrderedSet([0, 1, 2, 3]), [1, 2, 3])
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 2, 3])
+    self.intersection([2, 4, 5], [1, 2, 3, 4])
+    # doctest want:
+    # OrderedSet([2])
+    OrderedSet.intersection(OrderedSet([1, 2, 3]))
+    # doctest want:
+    # OrderedSet([1, 2, 3])
+
+
+def test_OrderedSet_update():
+    self = OrderedSet([1, 2, 3])
+    self.update([3, 1, 5, 1, 4])
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 2, 3, 5, 4])
+
+
+def test_OrderedSet_index():
+    import pytest
+    self = OrderedSet([1, 2, 3])
+    assert self.index(1) == 0
+    assert self.index(2) == 1
+    assert self.index(3) == 2
+    with pytest.raises(IndexError):
+        self[4]
+
+
+def test_OrderedSet_copy():
+    self = OrderedSet([1, 2, 3])
+    other = self.copy()
+    assert self == other and self is not other
+
+
+def test_OrderedSet_difference():
+    OrderedSet([1, 2, 3]).difference(OrderedSet([2]))
+    # doctest want:
+    # OrderedSet([1, 3])
+    OrderedSet([1, 2, 3]) - OrderedSet([2])
+    # doctest want:
+    # OrderedSet([1, 3])
+
+
+def test_OrderedSet_issubset():
+    OrderedSet([1, 2, 3]).issubset({1, 2})
+    # doctest want:
+    # False
+    OrderedSet([1, 2, 3]).issubset({1, 2, 3, 4})
+    # doctest want:
+    # True
+    OrderedSet([1, 2, 3]).issubset({1, 4, 3, 5})
+    # doctest want:
+    # False
+
+
+def test_OrderedSet_issuperset():
+    OrderedSet([1, 2]).issuperset([1, 2, 3])
+    # doctest want:
+    # False
+    OrderedSet([1, 2, 3, 4]).issuperset({1, 2, 3})
+    # doctest want:
+    # True
+    OrderedSet([1, 4, 3, 5]).issuperset({1, 2, 3})
+    # doctest want:
+    # False
+
+
+def test_OrderedSet_symmetric_difference():
+    self = OrderedSet([1, 4, 3, 5, 7])
+    other = OrderedSet([9, 7, 1, 3, 2])
+    self.symmetric_difference(other)
+    # doctest want:
+    # OrderedSet([4, 5, 9, 2])
+
+
+def test_OrderedSet_difference_update():
+    self = OrderedSet([1, 2, 3])
+    self.difference_update(OrderedSet([2]))
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 3])
+
+
+def test_OrderedSet_intersection_update():
+    self = OrderedSet([1, 4, 3, 5, 7])
+    other = OrderedSet([9, 7, 1, 3, 2])
+    self.intersection_update(other)
+    print(self)
+    # doctest want:
+    # OrderedSet([1, 3, 7])
+
+
+def test_OrderedSet_symmetric_difference_update():
+    self = OrderedSet([1, 4, 3, 5, 7])
+    other = OrderedSet([9, 7, 1, 3, 2])
+    self.symmetric_difference_update(other)
+    print(self)
+    # doctest want:
+    # OrderedSet([4, 5, 9, 2])

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 import pickle
 import pytest
+import collections
 from ordered_set import OrderedSet
 
 
@@ -151,3 +152,60 @@ def test_empty_repr():
 def test_eq_wrong_type():
     set1 = OrderedSet()
     assert set1 != 2
+
+
+def test_ordered_equality():
+    # Ordered set checks order against sequences.
+    assert OrderedSet([1, 2]) == OrderedSet([1, 2])
+    assert OrderedSet([1, 2]) == [1, 2]
+    assert OrderedSet([1, 2]) == (1, 2)
+    assert OrderedSet([1, 2]) == collections.deque([1, 2])
+
+
+def test_ordered_inequality():
+    # Ordered set checks order against sequences.
+    assert OrderedSet([1, 2]) != OrderedSet([2, 1])
+
+    assert OrderedSet([1, 2]) != [2, 1]
+    assert OrderedSet([1, 2]) != [2, 1, 1]
+
+    assert OrderedSet([1, 2]) != (2, 1)
+    assert OrderedSet([1, 2]) != (2, 1, 1)
+
+    # Note: in Python 2.7 deque does not inherit from Sequence, but __eq__
+    # contains an explicit check for this case for python 2/3 compatibility.
+    assert OrderedSet([1, 2]) != collections.deque([2, 1])
+    assert OrderedSet([1, 2]) != collections.deque([2, 2, 1])
+
+
+def test_unordered_equality():
+    # Unordered set checks order against non-sequences.
+    assert OrderedSet([1, 2]) == set([1, 2])
+    assert OrderedSet([1, 2]) == frozenset([2, 1])
+
+    assert OrderedSet([1, 2]) == {1: 'a', 2: 'b'}
+    assert OrderedSet([1, 2]) == {1: 1, 2: 2}.keys()
+    assert OrderedSet([1, 2]) == {1: 1, 2: 2}.values()
+
+    # Corner case: OrderedDict is not a Sequence, so we don't check for order,
+    # even though it does have the concept of order.
+    assert OrderedSet([1, 2]) == collections.OrderedDict([(2, 2), (1, 1)])
+
+    # Corner case: We have to treat iterators as unordered because there
+    # is nothing to distinguish an ordered and unordered iterator
+    assert OrderedSet([1, 2]) == iter([1, 2])
+    assert OrderedSet([1, 2]) == iter([2, 1])
+    assert OrderedSet([1, 2]) == iter([2, 1, 1])
+
+
+def test_unordered_inequality():
+    assert OrderedSet([1, 2]) != set([])
+    assert OrderedSet([1, 2]) != frozenset([2, 1, 3])
+
+    assert OrderedSet([1, 2]) != {2: 'b'}
+    assert OrderedSet([1, 2]) != {1: 1, 4: 2}.keys()
+    assert OrderedSet([1, 2]) != {1: 1, 2: 3}.values()
+
+    # Corner case: OrderedDict is not a Sequence, so we don't check for order,
+    # even though it does have the concept of order.
+    assert OrderedSet([1, 2]) != collections.OrderedDict([(2, 2), (3, 1)])

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = pypy, pypy3, py26, py27, py33, py34, py35
 
 [testenv]
-deps = nose
-commands = nosetests
+deps = pytest
+commands = pytest


### PR DESCRIPTION
This is a fairly large PR in terms of text, but I think the content is manageable for review.


It seems like this is the best implementation of OrderedSet on PYPI, but unfortunately it is missing functions implemented by the builtin set object like: `intersection`, `symmetric_difference_update`, and `issubset`. This PR adds implementations for these functions. 

A brief summary of changes is: 
* Implement all functions exposed in Python's builtin `set` API.
* Replace nose with pytest
* Add TravisCI and corresponding badges in the README 
* Change __getitem__(slice(None)) to return a copy instead of a self reference. 

As for reasoning behind these changes: 

* I think OrderedSet should serve as a drop-in replacement for set, and therefore should implement the full API. 
* I've replaced nose with pytest, because nose is [deprecated]. (http://nose.readthedocs.io/en/latest/index.html). 
* TravisCI serves as a public facing CI, so it can see that all tests pass without having to trust text in the README. This also lets the readme publicly display test coverage, and there is a nice pypi integration badge as well. 
* The `__getitem__` change may be the most debatable. The previous docs stated that `OrderedSet()[:]` would return an exact self reference, but I want to argue against this behavior. The main point is that this deviates from a standard behavior taken by other Mutable Python objects. Hopefully this code snippet illustrates my point: 

```python
>>> x = [1, 2, 3]
>>> x[:] is x
False

>>> x = np.array([1, 2, 3])
>>> x[:] is x
False

>>> # Why should OrderedSet have behavior different than a list here?
>>> x = OrderedSet([1, 2, 3])
>>> x[:] is x
True
```

A potential counter point may be that `tuple([1, 2, 3])[:]`, does return a reference to itself, but `tuple` is an immutable object, where as `OrderedSet` is not.

Unfortunately, even though this change is relatively minor it is a potentially breaking change that requires a major version update. My PR includes that as well. If I fail to convince you that this is a good idea, it can obviously be taken out and the minor version can be incremented. 

----------------------------

Note: I'm submitting the PR in its current state to gauge interest. Some of the code --- especially the tests --- needs a bit of tweaking to match the style of the other code. I will do this work if the maintainers like the general changes. 

I have my own implementation of OrderedSet, also based on Raymond Hettiger's original recipe, in my [utility package](https://github.com/Erotemic/ubelt/blob/master/ubelt/orderedset.py) but I'd like to rely on a standard pypi package instead. Also, I agree that nobody wants O(1) deletes in exchange for O(N) lookups. Thus most of this PR was simply copy and pasted from my implementation. 

All of the new tests were autogenerated from the doctests in my old package. As such, the stdout way of testing results doesn't work and all tests would need to be updated to actually check for the right values. Lastly, many of the tests might be redundant with existing tests. Again, I do the work to make these fixes if there is any interest in merging this PR. 

A summary of the cleanup work that would need to be done is: 

- [x] change travis targets in the readme to point at `LuminosoInsight` instead of `Erotemic`. 
- [x] Ensure that all test outputs are being checked
- [x] Either enable doctests in CI testing? or Remove doctests from the main module? 