### PR TITLE
Cleanups to metadata, docs, and tests

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Luminoso Technologies, Inc.
+Copyright (c) 2018 Luminoso Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This module's changes are as follows:
 
 - `index()` just returns the index of an item
 
-- Added a __getstate__ and __setstate__ so it can be pickled
+- Added a `__getstate__` and `__setstate__` so it can be pickled
 
-- Added __getitem__
+- Added `__getitem__`
 
 - `__getitem__` and `index()` can be passed lists or arrays, looking up
   all the elements in them to perform NumPy-like "fancy indexing"

--- a/README.md
+++ b/README.md
@@ -11,15 +11,25 @@ and released under the MIT license:
 
     http://code.activestate.com/recipes/576694-orderedset/
 
-Rob Speer's changes are as follows:
+This module's changes are as follows:
 
-    - changed the content from a doubly-linked list to a regular Python list.
-      Seriously, who wants O(1) deletes but O(N) lookups by index?
-    - add() returns the index of the added item
-    - index() just returns the index of an item
-    - added a __getstate__ and __setstate__ so it can be pickled
-    - added __getitem__
-    - __getitem__ and index() can be passed lists or arrays, looking up all
-      the elements in them to perform NumPy-like "fancy indexing"
+- Changed the content from a doubly-linked list to a regular Python list.
+  The ActiveState version has O(N) lookups by index and O(1) deletion;
+  this version has O(1) lookups by index and O(N) deletion, which seems
+  more useful in most cases.
 
-Tested on Python 2.6, 2.7, 3.3, 3.4, 3.5, PyPy, and PyPy3.
+- `add()` returns the index of the added item
+
+- `index()` just returns the index of an item
+
+- Added a __getstate__ and __setstate__ so it can be pickled
+
+- Added __getitem__
+
+- `__getitem__` and `index()` can be passed lists or arrays, looking up
+  all the elements in them to perform NumPy-like "fancy indexing"
+
+- The class implements the abstract base classes `collections.MutableSet`
+  and `collections.Sequence`
+
+Tested on Python 2.7, 3.3, 3.4, 3.5, PyPy, and PyPy3.

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -4,15 +4,6 @@ entry has an index that can be looked up.
 
 Based on a recipe originally posted to ActiveState Recipes by Raymond Hettiger,
 and released under the MIT license.
-
-Rob Speer's changes are as follows:
-
-    - changed the content from a doubly-linked list to a regular Python list.
-      Seriously, who wants O(1) deletes but O(N) lookups by index?
-    - add() returns the index of the added item
-    - index() just returns the index of an item
-    - added a __getstate__ and __setstate__ so it can be pickled
-    - added __getitem__
 """
 import collections
 import itertools as it
@@ -71,8 +62,8 @@ class OrderedSet(collections.MutableSet, collections.Sequence):
         If `index` is a slice, you will get back that slice of items. If it's
         the slice [:], a copy of this object is returned.
 
-        If `index` is an iterable, you'll get the OrderedSet of items
-        corresponding to those indices. This is similar to NumPy's
+        If `index` is a list or a similar iterable, you'll get the OrderedSet
+        of items corresponding to those indices. This is similar to NumPy's
         "fancy indexing".
 
         Example:
@@ -282,11 +273,12 @@ class OrderedSet(collections.MutableSet, collections.Sequence):
             >>> self == OrderedSet([3, 2, 1])
             False
         """
-        # In python 2 deque is not a Sequence,
-        # always treat deque it as one for compatibility
+        # In Python 2 deque is not a Sequence, so treat it as one for
+        # consistent behavior with Python 3.
         if isinstance(other, (collections.Sequence, collections.deque)):
-            # Ordered Check
-            return len(self) == len(other) and self.items == list(other)
+            # Check that this OrderedSet contains the same elements, in the
+            # same order, as the other object.
+            return list(self) == list(other)
         try:
             other_as_set = set(other)
         except TypeError:

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,25 @@
 from setuptools import setup
 
+DESCRIPTION = open('README.md', encoding='utf-8').read()
+
+
 setup(
     name="ordered-set",
-    version = '2.0.2',
+    version = '3.0.0',
     maintainer='Luminoso Technologies, Inc.',
-    maintainer_email='rob@luminoso.com',
+    maintainer_email='rspeer@luminoso.com',
     license = "MIT-LICENSE",
     url = 'http://github.com/LuminosoInsight/ordered-set',
     platforms = ["any"],
     description = "A MutableSet that remembers its order, so that every entry has an index.",
+    long_description=DESCRIPTION,
+    long_description_content_type='text/markdown',
     py_modules=['ordered_set'],
     package_data={'': ['MIT-LICENSE']},
     include_package_data=True,
-    test_suite='nose.collector',
+    setup_requires=['pytest-runner'],
     tests_require=['pytest'],
+    python_requires='>=2.7',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={'': ['MIT-LICENSE']},
     include_package_data=True,
     setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pytest-cov'],
     python_requires='>=2.7',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test.py
+++ b/test.py
@@ -178,6 +178,12 @@ def test_ordered_inequality():
     assert OrderedSet([1, 2]) != collections.deque([2, 2, 1])
 
 
+def test_comparisons():
+    # Comparison operators on sets actually test for subset and superset.
+    assert OrderedSet([1, 2]) < OrderedSet([1, 2, 3])
+    assert OrderedSet([1, 2]) > {1}
+
+
 def test_unordered_equality():
     # Unordered set checks order against non-sequences.
     assert OrderedSet([1, 2]) == set([1, 2])


### PR DESCRIPTION
- Updated the metadata in setup.py
- Fixed the missing dependency on `pytest-cov` when testing
- Added tests for set comparison operators
- Cleanups to docstrings
- Simplified the ordered version of `__eq__`