### PR TITLE
Rewrite the documentation with doctests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .coverage
 .pytest_cache
 htmlcov
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 before_install:
   - pip install pip -U
   - pip install pytest -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 before_install:
   - pip install pip -U
   - pip install pytest -U

--- a/README.md
+++ b/README.md
@@ -2,34 +2,103 @@
 [![Codecov](https://codecov.io/github/LuminosoInsight/ordered-set/badge.svg?branch=master&service=github)](https://codecov.io/github/LuminosoInsight/ordered-set?branch=master)
 [![Pypi](https://img.shields.io/pypi/v/ordered-set.svg)](https://pypi.python.org/pypi/ordered-set)
 
-
 An OrderedSet is a custom MutableSet that remembers its order, so that every
 entry has an index that can be looked up.
 
-Based on a recipe originally posted to ActiveState Recipes by Raymond Hettiger,
-and released under the MIT license:
+## Usage examples
 
-http://code.activestate.com/recipes/576694-orderedset/
+An OrderedSet is created and used like a set:
 
-This module's changes are as follows:
+    >>> from ordered_set import OrderedSet
 
-- Changed the content from a doubly-linked list to a regular Python list.
-  The ActiveState version has O(N) lookups by index and O(1) deletion;
-  this version has O(1) lookups by index and O(N) deletion, which seems
-  more useful in most cases.
+    >>> letters = OrderedSet('abracadabra')
 
-- `add()` returns the index of the added item
+    >>> letters
+    OrderedSet(['a', 'b', 'r', 'c', 'd'])
 
-- `index()` just returns the index of an item
+    >>> 'r' in letters
+    True
 
-- Added a `__getstate__` and `__setstate__` so it can be pickled
+It is efficient to find the index of an entry in an OrderedSet, or find an
+entry by its index. To help with this use case, the `.add()` method returns
+the index of the added item, whether it was already in the set or not.
 
-- Added `__getitem__`
+    >>> letters.index('r')
+    2
 
-- `__getitem__` and `index()` can be passed lists or arrays, looking up
-  all the elements in them to perform NumPy-like "fancy indexing"
+    >>> letters[2]
+    'r'
 
-- The class implements the abstract base classes `collections.MutableSet`
-  and `collections.Sequence`
+    >>> letters.add('r')
+    2
 
-Tested on Python 2.7, 3.3, 3.4, 3.5, PyPy, and PyPy3.
+    >>> letters.add('x')
+    5
+
+OrderedSets implement the union (`|`), intersection (`&`), and difference (`-`)
+operators like sets do.
+
+    >>> letters |= OrderedSet('shazam')
+
+    >>> letters
+    OrderedSet(['a', 'b', 'r', 'c', 'd', 'x', 's', 'h', 'z', 'm'])
+
+    >>> letters & set('aeiou')
+    OrderedSet(['a'])
+
+    >>> letters -= 'abcd'
+
+    >>> letters
+    OrderedSet(['r', 'x', 's', 'h', 'z', 'm'])
+
+The `__getitem__()` and `index()` methods have been extended to accept any
+iterable except a string, to perform NumPy-like "fancy indexing".
+
+    >>> letters = OrderedSet('abracadabra')
+
+    >>> letters[[0, 2, 3]]
+    OrderedSet(['a', 'r', 'c'])
+
+    >>> letters.index(['a', 'r', 'c'])
+    [0, 2, 3]
+
+This combination of features makes OrderedSet a simple implementation of many
+of the things that `pandas.Index` is used for. An OrderedSet can be used as a
+bi-directional mapping between a sparse vocabulary and dense index numbers.
+
+OrderedSet implements `__getstate__` and `__setstate__` so it can be pickled,
+and implements the abstract base classes `collections.MutableSet` and
+`collections.Sequence`.
+
+
+## Authors
+
+OrderedSet was implemented by Rob Speer. Jon Crall contributed changes and
+tests to make it fit the Python set API.
+
+
+## Comparisons
+
+The original implementation of OrderedSet was a [recipe posted to ActiveState
+Recipes][recipe] by Raymond Hettiger, released under the MIT license.
+
+[recipe]: http://code.activestate.com/recipes/576694-orderedset/
+
+Hettiger's implementation kept its content in a doubly-linked list referenced by a
+dict. As a result, looking up an item by its index was an O(N) operation, while
+deletion was O(1).
+
+This version makes different trade-offs for the sake of efficient lookups. Its
+content is a standard Python list instead of a doubly-linked list. This
+provides O(1) lookups by index at the expense of O(N) deletion, as well as
+slightly faster iteration.
+
+If you were to use a Python `dict` as an OrderedSet by ignoring its values, its
+lookups and deletions would be similar to Hettiger's implementation, with
+iteration speed similar to this implementation.
+
+
+## Compatibility
+
+OrderedSet is automatically tested on Python 2.7, 3.3, 3.4, 3.5, 3.6, and 3.7.
+We've checked more informally that it works on PyPy and PyPy3.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --doctest-modules test.py ordered_set.py
+addopts = --doctest-modules test.py ordered_set.py README.md --doctest-glob=README.md --ignore=setup.py
 
 norecursedirs = .git ignore build __pycache__


### PR DESCRIPTION
It's not that relevant anymore to compare this code to an ActiveState recipe, when no meaningful code from that original recipe remains. Instead, we should document in the README what OrderedSet does and what you can use it for.

Also, Python 3.7 is out and we should test it.