### PR TITLE
Add ordered-set-stubs installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ and implements the abstract base classes `collections.MutableSet` and
 `collections.Sequence`.
 
 
+## Type hinting
+To use type hinting features install `ordered-set-stubs` package from
+[PyPI](https://pypi.org/project/ordered-set-stubs/):
+
+    $ pip install ordered-set-stubs
+
+
 ## Authors
 
 OrderedSet was implemented by Robyn Speer. Jon Crall contributed changes and


### PR DESCRIPTION
I have found that:
1. `ordered_set.pyi` file is not copied to `ordered_set` package.
2. #26 is not fixed, `OrderedSet[str]`, for example, gives an error.

This PR fixes both.

After the merge, please release. Sorry, I didn't notice for the first time.