### PR TITLE
Trim trailing white space from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ before_install:
   - pip install pytest-cov -U
 install:
   - travis_retry pip install -e .
-script: 
+script:
   - travis_wait pytest --doctest-modules --cov-config .coveragerc --cov-report html --cov=ordered_set test.py
-    
-after_success: 
-  - codecov 
 
+after_success:
+  - codecov


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.