### PR TITLE
Fix error in NumPy fancy indexing

### DIFF
--- a/ordered_set.py
+++ b/ordered_set.py
@@ -87,14 +87,14 @@ class OrderedSet(MutableSet, Sequence):
         """
         if isinstance(index, slice) and index == SLICE_ALL:
             return self.copy()
+        elif is_iterable(index):
+            return [self.items[i] for i in index]
         elif hasattr(index, "__index__") or isinstance(index, slice):
             result = self.items[index]
             if isinstance(result, list):
                 return self.__class__(result)
             else:
                 return result
-        elif is_iterable(index):
-            return [self.items[i] for i in index]
         else:
             raise TypeError("Don't know how to index an OrderedSet by %r" % index)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ DESCRIPTION = open('README.md').read()
 
 setup(
     name="ordered-set",
-    version='3.1',
+    version='3.1.1',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     license="MIT-LICENSE",

--- a/test.py
+++ b/test.py
@@ -64,6 +64,9 @@ class FancyIndexTester:
     def __iter__(self):
         return iter(self.indices)
 
+    def __index__(self):
+        raise TypeError("NumPy arrays have weird __index__ methods")
+
     def __eq__(self, other):
         # Emulate NumPy being fussy about the == operator
         raise TypeError


### PR DESCRIPTION
NumPy arrays of integers have an `__index__` method -- it's meant to apply to scalars, and it raises an error if you actually try to run it on an array.

This ruined most cases where NumPy fancy indexing was supposed to work, because it ended up in the case for things with an `__index__` instead of things that are iterable.

If we move the `is_iterable` check first, we won't encounter this error.