### PR TITLE
v4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     package_data={'': ['MIT-LICENSE']},
     include_package_data=True,
     tests_require=['pytest'],
-    python_requires='>=2.7',
+    python_requires='>=2.7.8',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This changes equality comparisons completely to make them more consistent with how all the other data structures in Python stdlib behave.

- Comparisons with regular `set` and `frozenset` are order agnostic.
- Comparisons with other `OrderedSet` (and other ordered-set-like-things) are order sensitive.
- Previous equality comparison with list/deque/sequence was removed (this was unpythonic and had no precedent)
- Comparisons with unrelated types return `NotImplemented` - this is allowing the other type a chance to potentially handle the operation (as opposed to returning `False`)
- Major version number is bumped up because this is a backwards-incompat change.

The behaviour of equality comparison was modeled after the way `collections.OrderedDict` behaves (order agnostic vs regular dict, order sensitive vs other ordered dict).