### PR TITLE
Include pytest.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include MIT-LICENSE
 include test.py
+include pytest.ini


### PR DESCRIPTION
The test won't run properly in sdist without the proper parameters.