### PR TITLE
Directly distribute type hints via PEP 561

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,30 @@ in OrderedSet).
 
 
 ## Type hinting
-To use type hinting features install `ordered-set-stubs` package from
-[PyPI](https://pypi.org/project/ordered-set-stubs/):
 
-    $ pip install ordered-set-stubs
+OrderedSet works with generics, similar to other collection types like `typing.Set` and `typing.List`:
+
+    from ordered_set import OrderedSet
+
+
+    def receives_int(ordered_set: "OrderedSet[int]") -> "OrderedSet[int]"
+      return ordered_set
+
+
+    receives_int(OrderedSet(["ololo"]))
+
+In Python 3.7+, you can use `from __future__ import annotations` to drop the quotes:
+
+    from __future__ import annotations
+
+    from ordered_set import OrderedSet
+
+
+    def receives_int(ordered_set: OrderedSet[int]) -> OrderedSet[int]
+      return ordered_set
+
+
+    receives_int(OrderedSet(["ololo"]))
 
 
 ## Authors

--- a/py.typed
+++ b/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     description="A MutableSet that remembers its order, so that every entry has an index.",
     long_description=DESCRIPTION,
     long_description_content_type='text/markdown',
-    py_modules=['ordered_set'],
-    package_data={'': ['MIT-LICENSE']},
+    packages=[''],  # i.e., the root package
+    package_data={'': ['MIT-LICENSE', 'py.typed']},
     include_package_data=True,
     tests_require=['pytest'],
     python_requires='>=2.7',


### PR DESCRIPTION
There is already a type stub file (`ordered_set.pyi`), but this was not actually being distributed to end-users, so, they had to use the package `ordered-set-stubs`.

This uses the mechanisms from [PEP 561](https://www.python.org/dev/peps/pep-0561/) to ensure that the type stub file is properly distributed so that type hints work out-of-the-box, rather than requiring `ordered-set-stubs`.

[Per PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information), this requires two changes to `setup.py`:

1) Add a sentinel file `py.typed` and include this in `package_data`.
2) Use `packages` rather than `py_modules`, as the PEP states:

> This PEP does not support distributing typing information as part of module-only distributions. The code should be refactored into a package-based distribution and indicate that the package supports typing as described above.