### PR TITLE
Add `FrozenOrderedSet`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = pypy, pypy3, py27, py34, py35, py36, py37
 
 [testenv]
 deps = pytest
-commands = pytest
+commands = pytest {posargs}


### PR DESCRIPTION
Closes https://github.com/LuminosoInsight/ordered-set/issues/62. 

Just as the standard library has `set` and `frozenset`, this change would result in having `OrderedSet` and `FrozenOrderedSet`. The majority of users would default to `OrderedSet`, just as they default to `set`. But, `FrozenOrderedSet` fills a niche for users who need:

1) deduplication
2) consistent iteration order
3) immutability

Most of the implementation is the same as `OrderedSet`, outside of removing any methods that mutate, such as `discard()` and `clear()`. Notably, the constructor of `FrozenOrderedSet` calls `self.items = tuple(OrderedSet(iterable))`. This leverages the implementation of `OrderedSet`, but then converts it into an immutable tuple. Finally, we add a `__hash__` implementation, as it is safe to hash a `FrozenOrderedSet` (but not an `OrderedSet`).

For deduplication/DRY, we factor out a common `_AbstractOrderedSet` class that provides implementations for the shared methods like `__len__()` and `intersection()`. It is abstract, and `OrderedSet` and `FrozenOrderedSet` must set up how they actually store the internal data (e.g. mutable list vs. immutable tuple).

This runs the majority of unit tests for both `OrderedSet` and `FrozenOrderedSet` through Pytest's parametrization feature.