### PR TITLE
add "index" argument to pop method

### DIFF
--- a/ordered_set.py
+++ b/ordered_set.py
@@ -230,11 +230,12 @@ class OrderedSet(MutableSet[T], Sequence[T]):
     get_loc = index
     get_indexer = index
 
-    def pop(self) -> T:
+    def pop(self, index=-1) -> T:
         """
-        Remove and return the last element from the set.
+        Remove and return item at index (default last).
 
         Raises KeyError if the set is empty.
+        Raises IndexError if index is out of range.
 
         Example:
             >>> oset = OrderedSet([1, 2, 3])
@@ -244,8 +245,8 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         if not self.items:
             raise KeyError("Set is empty")
 
-        elem = self.items[-1]
-        del self.items[-1]
+        elem = self.items[index]
+        del self.items[index]
         del self.map[elem]
         return elem
 


### PR DESCRIPTION
Hello!
I think, it is more convenient for pop()  to have index option.

Added "index" argument to pop method to select items to pop.
Maintained KeyError if set is empty for compatibility.