### PR TITLE
fix packaging, remove vestiges of type stubs

### DIFF
--- a/ordered_set.py
+++ b/ordered_set.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 SLICE_ALL = slice(None)
-__version__ = "4.0"
+__version__ = "4.0.1"
 
 
 T = TypeVar("T")

--- a/py.typed
+++ b/py.typed
@@ -1,1 +1,0 @@
-# Marker file for PEP 561.

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,17 @@ DESCRIPTION = open('README.md').read()
 
 setup(
     name="ordered-set",
-    version='4.0',
+    version='4.0.1',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     license="MIT-LICENSE",
     url='https://github.com/LuminosoInsight/ordered-set',
     platforms=["any"],
-    description="A MutableSet that remembers its order, so that every entry has an index.",
+    description="A set that remembers its order, and allows looking up its items by their index in that order.",
     long_description=DESCRIPTION,
     long_description_content_type='text/markdown',
-    packages=[''],  # i.e., the root package
-    package_data={'': ['MIT-LICENSE', 'py.typed']},
+    py_modules=['ordered_set'],
+    package_data={'': ['MIT-LICENSE']},
     include_package_data=True,
     tests_require=['pytest'],
     python_requires='>=3.5',


### PR DESCRIPTION
The current setup.py installs files incorrectly to the root `site-packages`, because of a vestigial attempt to support PEP 561 type hints.