### PR TITLE
Fix Python 3.5 support

### DIFF
--- a/ordered_set.py
+++ b/ordered_set.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 SLICE_ALL = slice(None)
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 
 T = TypeVar("T")

--- a/ordered_set.py
+++ b/ordered_set.py
@@ -26,7 +26,11 @@ __version__ = "4.0.1"
 
 
 T = TypeVar("T")
-SetLike = Union[Sequence[T], Set[T]]
+
+# When Python 3.6 is the minimum version, we can define a type like this,
+# parameterizing the types that an OrderedSet can interoperate with:
+#
+# SetLike = Union[Sequence[T], Set[T]]
 
 
 def _is_atomic(obj: Any) -> bool:
@@ -183,7 +187,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
 
     append = add
 
-    def update(self, sequence: SetLike[T]) -> int:
+    def update(self, sequence: Union[Sequence[T], Set[T]]) -> int:
         """
         Update the set with the given iterable sequence, then return the index
         of the last element inserted.
@@ -329,7 +333,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         else:
             return set(self) == other_as_set
 
-    def union(self, *sets: SetLike[T]) -> "OrderedSet[T]":
+    def union(self, *sets: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
         """
         Combines all unique items.
         Each items order is defined by its first appearance.
@@ -348,11 +352,11 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         items = it.chain.from_iterable(containers)
         return cls(items)
 
-    def __and__(self, other: SetLike[T]) -> "OrderedSet[T]":
+    def __and__(self, other: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
         # the parent implementation of this is backwards
         return self.intersection(other)
 
-    def intersection(self, *sets: SetLike[T]) -> "OrderedSet[T]":
+    def intersection(self, *sets: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
         """
         Returns elements in common between all sets. Order is defined only
         by the first set.
@@ -374,7 +378,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             items = self
         return cls(items)
 
-    def difference(self, *sets: SetLike[T]) -> "OrderedSet[T]":
+    def difference(self, *sets: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
         """
         Returns all elements that are in this set but not the others.
 
@@ -396,7 +400,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             items = self
         return cls(items)
 
-    def issubset(self, other: SetLike[T]) -> bool:
+    def issubset(self, other: Union[Sequence[T], Set[T]]) -> bool:
         """
         Report whether another set contains this set.
 
@@ -412,7 +416,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             return False
         return all(item in other for item in self)
 
-    def issuperset(self, other: SetLike[T]) -> bool:
+    def issuperset(self, other: Union[Sequence[T], Set[T]]) -> bool:
         """
         Report whether this set contains another set.
 
@@ -428,7 +432,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             return False
         return all(item in self for item in other)
 
-    def symmetric_difference(self, other: SetLike[T]) -> "OrderedSet[T]":
+    def symmetric_difference(self, other: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
         """
         Return the symmetric difference of two OrderedSets as a new set.
         That is, the new set will contain all elements that are in exactly
@@ -456,7 +460,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         self.items = items
         self.map = {item: idx for (idx, item) in enumerate(items)}
 
-    def difference_update(self, *sets: SetLike[T]) -> None:
+    def difference_update(self, *sets: Union[Sequence[T], Set[T]]) -> None:
         """
         Update this OrderedSet to remove items from one or more other sets.
 
@@ -477,7 +481,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             items_to_remove |= items_as_set
         self._update_items([item for item in self.items if item not in items_to_remove])
 
-    def intersection_update(self, other: SetLike[T]) -> None:
+    def intersection_update(self, other: Union[Sequence[T], Set[T]]) -> None:
         """
         Update this OrderedSet to keep only items in another set, preserving
         their order in this set.
@@ -492,7 +496,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         other = set(other)
         self._update_items([item for item in self.items if item in other])
 
-    def symmetric_difference_update(self, other: SetLike[T]) -> None:
+    def symmetric_difference_update(self, other: Union[Sequence[T], Set[T]]) -> None:
         """
         Update this OrderedSet to remove items from another set, then
         add items from the other set that were not present in this set.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ DESCRIPTION = open('README.md').read()
 
 setup(
     name="ordered-set",
-    version='4.0.1',
+    version='4.0.2',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     license="MIT-LICENSE",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, pypy3, py27, py34, py35, py36, py37
+envlist = pypy3, py35, py36, py37
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
I accidentally broke Python 3.5 support using typing features that weren't supported yet. I've fixed the types, and also fixed the tox settings so we can test it.