### PR TITLE
Rebuild self.map after .pop()

### DIFF
--- a/ordered_set/__init__.py
+++ b/ordered_set/__init__.py
@@ -252,7 +252,8 @@ class OrderedSet(MutableSet[T], Sequence[T]):
 
     def pop(self, index=-1) -> T:
         """
-        Remove and return item at index (default last).
+        Remove and return item at index (default last), updating
+        self.map accordingly.
 
         Raises KeyError if the set is empty.
         Raises IndexError if index is out of range.
@@ -268,6 +269,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         elem = self.items[index]
         del self.items[index]
         del self.map[elem]
+        self.map = {item: idx for (idx, item) in enumerate(self.items)}
         return elem
 
     def discard(self, key: T) -> None:

--- a/test/test_ordered_set.py
+++ b/test/test_ordered_set.py
@@ -151,13 +151,20 @@ def test_update():
 
 
 def test_pop():
-    set1 = OrderedSet("ab")
-    elem = set1.pop()
-
-    assert elem == "b"
-    elem = set1.pop()
+    set1 = OrderedSet("abc")
+    elem = set1.pop(0)
 
     assert elem == "a"
+    assert set1.index('b') == 0
+    assert set1.index('c') == 1
+
+    elem = set1.pop()
+    assert elem == "c"
+    assert set1.index('b') == 0
+
+    elem = set1.pop()
+    assert elem == "b"
+    assert not set1.map
 
     pytest.raises(KeyError, set1.pop)
 


### PR DESCRIPTION
Resolves [Issue 83](https://github.com/rspeer/ordered-set/issues/83)